### PR TITLE
Make examples in «Replacing loops with array methods» equivalent

### DIFF
--- a/manuscript/book.md
+++ b/manuscript/book.md
@@ -34,8 +34,9 @@ For example, let’s convert an array of strings to `kebab-case` with a `for` l
 
 ```js
 const names = ['Bilbo Baggins', 'Gandalf', 'Gollum'];
+const kebabNames = [];
 for (let i = 0; i < names.length; i++) {
-  names[i] = _.kebabCase(names[i]);
+  kebabNames.push(_.kebabCase(names[i]));
 }
 ```
 


### PR DESCRIPTION
`for` and `map` examples in “Replacing loops with array methods” are not equivalent to each other. I think this change will make the examples less confusing. 